### PR TITLE
Manifest browser targets script

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,8 +15,7 @@ python -m venv env
 source env/bin/activate
 pip install kdl-py
 ```
-
-3. Run `package/main.py` to generate the extension manifest
+3. Run `cd package` then `python main.py firefox` or `python main.py chrome` to generate the extension manifest
 
 4. Run `deno task firefox` or `deno task chrome` to build the extension for your browser
 

--- a/package/main.py
+++ b/package/main.py
@@ -1,95 +1,134 @@
+import sys
 import kdl
 import json
 from pprint import pprint
 
-with open('manifest.kdl') as f: s = f.read()
-doc = kdl.parsefuncs.parse(s)
+TARGET_FIREFOX = 'firefox'
+TARGET_CHROME = 'chrome'
 
-manifest = {}
+DEFINE_BUILDDIR = '$BUILD_DIR'
 
-for node in doc.nodes:
-    match node.name:
-        case 'manifest-version':
-            manifest['manifest_version'] = node.args[0]
+def match_replace_define(source: str, define: str, value: str):
+    if source.find(define) != -1:
+        return str.replace(source, define, value)
 
-        case 'icons':
-            icons = {}
-            for icon in node.nodes:
-                icons[icon.name] = icon.args[0]
+    return source
 
-            manifest['icons'] = icons
+def build_manifest(target: str):
+    with open('manifest.kdl') as f: s = f.read()
+    doc = kdl.parsefuncs.parse(s)
 
-        case 'permissions':
-            manifest['permissions'] = [perm.name for perm in node.nodes]
+    manifest = {}
 
-        case 'defaults': # action
-            # Does not support 'default_icon'
-            action = {}
+    for node in doc.nodes:
+        match node.name:
+            case 'manifest-version':
+                manifest['manifest_version'] = node.args[0]
 
-            for default in node.nodes:
-                key = ""
-                match default.name:
-                    case 'popup':
-                        key = 'default_popup'
-                    case 'tooltip':
-                        key = 'default_title'
+            case 'icons':
+                icons = {}
+                for icon in node.nodes:
+                    icons[icon.name] = icon.args[0]
 
-                action[key] = default.args[0]
+                manifest['icons'] = icons
 
-            manifest['action'] = action
+            case 'permissions':
+                manifest['permissions'] = [perm.name for perm in node.nodes]
 
-        case 'injections': # content_scripts
-            # Only supports single-value fields
-            injections = []
-            for match in node.nodes:
-                obj = {}
+            case 'defaults': # action
+                # Does not support 'default_icon'
+                action = {}
 
-                for field in match.nodes:
+                for default in node.nodes:
                     key = ""
-                    match field.name:
-                        case 'run-at':
-                            obj['run_at'] = field.args[0]
-                            continue
-                        case 'match':
-                            key = 'matches'
-                        case 'script':
-                            key = 'js'
+                    match default.name:
+                        case 'popup':
+                            key = 'default_popup'
+                        case 'tooltip':
+                            key = 'default_title'
 
-                    obj[key] = field.args
+                    action[key] = default.args[0]
 
-                injections.append(obj)
+                manifest['action'] = action
 
-            manifest['content_scripts'] = injections
+            case 'injections': # content_scripts
+                # Only supports single-value fields
+                injections = []
+                for match in node.nodes:
+                    obj = {}
 
-        case 'background-script': # background
-            # Does not support type field
-            manifest['background'] = {"service_worker": node.args[0]}
+                    for field in match.nodes:
+                        key = ""
+                        match field.name:
+                            case 'run-at':
+                                obj['run_at'] = field.args[0]
+                                continue
+                            case 'match':
+                                key = 'matches'
+                            case 'script':
+                                key = 'js'
 
-        case 'resources': # web_accessible_resources
-            # Does not support 'use_dynamic_url'
-            # To-do: make files the parent key for matches and extension_ids to allow for both
-            resources = []
-            for resource in node.nodes:
-                obj = {}
+                        # match args against defs and update the values
+                        updatedargs = []
+                        for arg in field.args:
+                            v = match_replace_define(arg, DEFINE_BUILDDIR, target)
+                            if v != arg: # success
+                                v = f'build/{v}'
 
-                for field in resource.nodes:
-                    key = ""
-                    match field.name:
-                        case 'files':
-                            key = 'resources'
-                        case 'match':
-                            key = 'matches'
+                            updatedargs.append(v)
 
-                    obj[key] = field.args
+                        obj[key] = updatedargs
 
-                resources.append(obj)
+                    injections.append(obj)
 
-            manifest['web_accessible_resources'] = resources
+                manifest['content_scripts'] = injections
 
-        case _:
-            try:
-                manifest[node.name] = node.args[0]
-            except:
-                pprint(node)
+            case 'background-script': # background
+                # Does not support type field
+                manifest['background'] = {"service_worker": node.args[0]}
 
-with open("../manifest.json", "w") as f: json.dump(manifest, f, indent=2)
+            case 'resources': # web_accessible_resources
+                # Does not support 'use_dynamic_url'
+                # To-do: make files the parent key for matches and extension_ids to allow for both
+                resources = []
+                for resource in node.nodes:
+                    obj = {}
+
+                    for field in resource.nodes:
+                        key = ""
+                        match field.name:
+                            case 'files':
+                                key = 'resources'
+                            case 'match':
+                                key = 'matches'
+
+                        obj[key] = field.args
+
+                    resources.append(obj)
+
+                manifest['web_accessible_resources'] = resources
+
+            case _:
+                try:
+                    manifest[node.name] = node.args[0]
+                except:
+                    pprint(node)
+
+    with open("../manifest.json", "w") as f: json.dump(manifest, f, indent=2)
+
+def run(args: list[str]):
+    if len(args) != 2: # only supporting firefox and chrome
+        print(f'expected 2 arguments, recieved {len(args)}')
+        return
+
+    TARGET = args[1]
+    if TARGET == TARGET_CHROME:
+        build_manifest(TARGET_CHROME)
+    elif TARGET == TARGET_FIREFOX:
+        build_manifest(TARGET_FIREFOX)
+    else:
+        print('could not build manifest for specified target...')
+
+
+if __name__ == '__main__':
+    run(sys.argv)

--- a/package/manifest.kdl
+++ b/package/manifest.kdl
@@ -25,7 +25,7 @@ defaults {
 injections {
     inject {
         match "<all_urls>"
-        script "build/injected.js"
+        script "$BUILD_DIR/injected.js"
         run-at "document_start"
     }
 }


### PR DESCRIPTION
Build time define injection through python to support dynamic build paths.
This gives us the ability to generate `manifest.json` per browser.

Use $BUILD_DIR in `manifest.kdl` in-place of browser based build paths.

You can easily add support for more definitions in `package/main.py`.

Also, I have updated the docs to reflect the new process for executing running the manifest generation process.